### PR TITLE
[BUG]: Fix social media icons linking to website instead of actual social pages #244

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -298,30 +298,30 @@ export const socials = [
     id: "0",
     title: "Discord",
     iconUrl: discordBlack,
-    url: "#",
+    url: "https://discord.com", // ✅ Updated
   },
   {
     id: "1",
     title: "Twitter",
     iconUrl: twitter,
-    url: "#",
+    url: "https://twitter.com", // ✅ Updated
   },
   {
     id: "2",
     title: "Instagram",
     iconUrl: instagram,
-    url: "#",
+    url: "https://www.instagram.com", // ✅ Updated
   },
   {
     id: "3",
     title: "Telegram",
     iconUrl: telegram,
-    url: "#",
+    url: "https://telegram.org", // ✅ Updated
   },
   {
     id: "4",
     title: "Facebook",
     iconUrl: facebook,
-    url: "#",
+    url: "https://www.facebook.com", // ✅ Updated
   },
 ];


### PR DESCRIPTION
**Description:**

This PR fixes the social media links on the website footer by pointing each icon to its correct platform #244 :

- Discord → `https://discord.com`
- Twitter → `https://twitter.com`
- Instagram → `https://www.instagram.com`
- Telegram → `https://telegram.org`
- Facebook → `https://www.facebook.com`

**Changes Made:**

- Updated the `socials `array URLs to the respective social media sites.
- Ensured each icon now correctly redirects users to the intended platform.

**Result:**

Footer social media links are fully functional and direct users to the correct sites.